### PR TITLE
Integrate OpenPBR materials with OptiX pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "ivf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1172,8 @@ dependencies = [
  "rav1e",
  "ravif",
  "rgb",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1173,6 +1181,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scan_fmt"
@@ -1198,6 +1212,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ rgb = "0.8"
 rav1e = "0.8.1"
 avif-parse = "1.3"
 avif-serialize = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [build-dependencies]
 cmake = "0.1.54"

--- a/materials.json
+++ b/materials.json
@@ -1,0 +1,9 @@
+[
+  {
+    "base_color": [0.8, 0.8, 0.8],
+    "emission": [0.0, 0.0, 0.0],
+    "specular": [0.04, 0.04, 0.04],
+    "roughness": 0.5,
+    "metallic": 0.0
+  }
+]


### PR DESCRIPTION
## Summary
- Expand OptiX hitgroup data to carry a full OpenPBR material and add GGX-based BRDF sampling/evaluation.
- Populate and upload the new material struct in the host OptiX wrapper with an FFI entry point for updates.
- Expose matching Rust-side material definitions, JSON loading, and material upload before rendering.

## Testing
- `cargo check` *(fails: Failed to find nvcc)*


------
https://chatgpt.com/codex/tasks/task_e_68bf4912adfc832f93d8105cea320e00