### PR TITLE
Add scaffolding for OpenPGL-based path guiding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ codegen-units = 1
 [features]
 default = []
 fast-demosaic = []
+guiding = []

--- a/GUIDING_NOTES.md
+++ b/GUIDING_NOTES.md
@@ -1,0 +1,9 @@
+# Path Guiding Notes
+
+This repository contains stubbed support for CPU trained / GPU sampled path guiding.
+The implementation follows the OpenPGL based interface but does not yet provide a
+fully functional guiding solution. Use the `--guiding` command line flag together
+with the `guiding` cargo feature to enable the scaffolding.
+
+Currently only placeholder logic is present; OpenPGL data is ignored and sampling
+falls back to the original behaviour.

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,10 @@ use std::{env, fs, path::PathBuf};
 fn main() {
     println!("cargo:rerun-if-changed=optix/CMakeLists.txt");
     println!("cargo:rerun-if-changed=optix/optix_wrapper.cpp");
+    println!("cargo:rerun-if-changed=optix/openpgl_bridge.cpp");
+    println!("cargo:rerun-if-changed=optix/openpgl_bridge.h");
+    println!("cargo:rerun-if-changed=optix/guiding_gpu.h");
+    println!("cargo:rerun-if-changed=optix/guiding_gpu.cuh");
     println!("cargo:rerun-if-changed=optix/optix_device.cu");
     println!("cargo:rerun-if-changed=optix/cuda_kernels.cu");
 

--- a/optix/CMakeLists.txt
+++ b/optix/CMakeLists.txt
@@ -89,6 +89,7 @@ target_include_directories(optix_stubs PUBLIC "${OPTIX_ROOT}/include")
 # ---- Host wrapper (DLL) ----
 add_library(optix_wrapper SHARED
         optix_wrapper.cpp
+        openpgl_bridge.cpp
 )
 add_dependencies(optix_wrapper optix_ptx cuda_ptx)
 
@@ -114,6 +115,14 @@ target_compile_definitions(optix_wrapper PRIVATE OPTIX_PTX_PATH=\"${PTX_SLASHED}
 set_target_properties(optix_wrapper PROPERTIES
         CUDA_SEPARABLE_COMPILATION ON
 )
+
+find_path(OPENPGL_INCLUDE_DIR openpgl/version.h PATHS ENV OPENPGL_ROOT PATH_SUFFIXES include)
+find_library(OPENPGL_LIBRARY NAMES openpgl PATHS ENV OPENPGL_ROOT PATH_SUFFIXES lib)
+if(OPENPGL_INCLUDE_DIR AND OPENPGL_LIBRARY)
+  target_include_directories(optix_wrapper PRIVATE ${OPENPGL_INCLUDE_DIR})
+  target_link_libraries(optix_wrapper PRIVATE ${OPENPGL_LIBRARY})
+  target_compile_definitions(optix_wrapper PRIVATE HAVE_OPENPGL)
+endif()
 
 target_link_libraries(optix_wrapper
         PRIVATE

--- a/optix/guiding_gpu.cuh
+++ b/optix/guiding_gpu.cuh
@@ -1,0 +1,33 @@
+#include <vector_functions.h>
+#pragma once
+#include <cuda.h>
+#include <vector_types.h>
+#include <stdint.h>
+#include <math_constants.h>
+
+struct GuideRegion { float3 bmin,bmax; uint32_t lobe_ofs,lobe_num; };
+struct GuideLobe   { float3 mu; float kappa; float weight; float3 rgb; };
+struct GuideGPU {
+  CUdeviceptr d_regions; uint32_t region_count;
+  CUdeviceptr d_lobes;   uint32_t lobe_count;
+  CUdeviceptr d_grid;    int3 grid_res; float3 grid_min,grid_max,cell_size;
+};
+
+__device__ __forceinline__ int guiding_region_id(const GuideGPU& G,const float3& P){
+  float3 rel=make_float3((P.x-G.grid_min.x)/G.cell_size.x,
+                         (P.y-G.grid_min.y)/G.cell_size.y,
+                         (P.z-G.grid_min.z)/G.cell_size.z);
+  int3 c;
+  c.x=max(0,min(int(rel.x),G.grid_res.x-1));
+  c.y=max(0,min(int(rel.y),G.grid_res.y-1));
+  c.z=max(0,min(int(rel.z),G.grid_res.z-1));
+  uint32_t id=((uint32_t*)G.d_grid)[(c.z*G.grid_res.y+c.y)*G.grid_res.x+c.x];
+  return id==0xFFFFFFFFu?-1:int(id);
+}
+
+__device__ inline float3 vmf_sample(const float3& mu,float /*kappa*/,float2 /*u*/){
+  return mu;
+}
+__device__ inline float vmf_pdf(const float3& /*mu*/,float /*kappa*/,const float3& /*wi*/){
+  return 1.f/(4.f*CUDART_PI_F);
+}

--- a/optix/guiding_gpu.h
+++ b/optix/guiding_gpu.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "openpgl_bridge.h"
+#include <cuda.h>
+#include <vector_types.h>
+#include <stdint.h>
+
+struct GuideRegion { float3 bmin,bmax; uint32_t lobe_ofs,lobe_num; };
+struct GuideLobe   { float3 mu; float kappa; float weight; float3 rgb; };
+
+struct GuideGPU {
+  CUdeviceptr d_regions; uint32_t region_count;
+  CUdeviceptr d_lobes;   uint32_t lobe_count;
+  CUdeviceptr d_grid;    int3 grid_res; float3 grid_min,grid_max,cell_size;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void guiding_upload_snapshot(const struct pgl_region* regions,uint32_t n_regions,
+                             const struct pgl_lobe* lobes,uint32_t n_lobes);
+void guiding_set_enabled(int enabled);
+
+#ifdef __cplusplus
+}
+#endif

--- a/optix/openpgl_bridge.cpp
+++ b/optix/openpgl_bridge.cpp
@@ -1,0 +1,27 @@
+#include "openpgl_bridge.h"
+#include <vector>
+struct DummyStorage {
+  std::vector<int> dummy;
+};
+
+pgl_dev_t pgl_dev_create(int){return nullptr;}
+void pgl_dev_destroy(pgl_dev_t){}
+
+pgl_field_t pgl_field_create(pgl_dev_t,const float[3],const float[3]){return nullptr;}
+void pgl_field_destroy(pgl_field_t){}
+
+pgl_samples_t pgl_samples_create(){return new DummyStorage;}
+void pgl_samples_destroy(pgl_samples_t s){delete static_cast<DummyStorage*>(s);}
+
+void pgl_samples_add_surface(pgl_samples_t,const float[3],const float[3],const float[3],int){}
+
+void pgl_field_update(pgl_field_t,pgl_samples_t){}
+
+void pgl_field_snapshot(pgl_field_t,const pgl_region** regions,uint32_t* region_count,const pgl_lobe** lobes,uint32_t* lobe_count){
+  static pgl_region empty_region{};
+  static pgl_lobe   empty_lobe{};
+  if(regions) *regions=&empty_region;
+  if(region_count) *region_count=0;
+  if(lobes) *lobes=&empty_lobe;
+  if(lobe_count) *lobe_count=0;
+}

--- a/optix/openpgl_bridge.h
+++ b/optix/openpgl_bridge.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* pgl_dev_t;
+typedef void* pgl_field_t;
+typedef void* pgl_samples_t;
+
+pgl_dev_t   pgl_dev_create(int num_threads);
+void        pgl_dev_destroy(pgl_dev_t);
+
+pgl_field_t pgl_field_create(pgl_dev_t dev, const float world_min[3], const float world_max[3]);
+void        pgl_field_destroy(pgl_field_t);
+
+pgl_samples_t pgl_samples_create();
+void          pgl_samples_destroy(pgl_samples_t);
+
+void pgl_samples_add_surface(pgl_samples_t s,
+   const float pos[3],
+   const float dir_in[3],
+   const float weight_rgb[3],
+   int is_delta);
+
+void pgl_field_update(pgl_field_t, pgl_samples_t);
+
+struct pgl_region { float bmin[3]; float bmax[3]; uint32_t lobe_ofs; uint32_t lobe_num; };
+struct pgl_lobe   { float mu[3]; float kappa; float weight; float rgb[3]; };
+
+void pgl_field_snapshot(pgl_field_t,
+   const struct pgl_region** regions, uint32_t* region_count,
+   const struct pgl_lobe**   lobes,   uint32_t* lobe_count);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/guiding.rs
+++ b/src/guiding.rs
@@ -1,0 +1,69 @@
+#[cfg(feature = "guiding")]
+use std::ffi::{c_int, c_void};
+
+#[cfg(feature = "guiding")]
+#[repr(C)]
+pub struct PglRegion {
+    pub bmin: [f32; 3],
+    pub bmax: [f32; 3],
+    pub lobe_ofs: u32,
+    pub lobe_num: u32,
+}
+#[cfg(feature = "guiding")]
+#[repr(C)]
+pub struct PglLobe {
+    pub mu: [f32; 3],
+    pub kappa: f32,
+    pub weight: f32,
+    pub rgb: [f32; 3],
+}
+
+#[cfg(feature = "guiding")]
+extern "C" {
+    pub fn pgl_dev_create(num_threads: c_int) -> *mut c_void;
+    pub fn pgl_dev_destroy(dev: *mut c_void);
+    pub fn pgl_field_create(
+        dev: *mut c_void,
+        world_min: *const f32,
+        world_max: *const f32,
+    ) -> *mut c_void;
+    pub fn pgl_field_destroy(field: *mut c_void);
+    pub fn pgl_samples_create() -> *mut c_void;
+    pub fn pgl_samples_destroy(s: *mut c_void);
+    pub fn pgl_samples_add_surface(
+        s: *mut c_void,
+        pos: *const f32,
+        dir_in: *const f32,
+        weight_rgb: *const f32,
+        is_delta: c_int,
+    );
+    pub fn pgl_field_update(field: *mut c_void, samples: *mut c_void);
+    pub fn pgl_field_snapshot(
+        field: *mut c_void,
+        regions: *mut *const PglRegion,
+        region_count: *mut u32,
+        lobes: *mut *const PglLobe,
+        lobe_count: *mut u32,
+    );
+    pub fn guiding_upload_snapshot(
+        regions: *const PglRegion,
+        n_regions: u32,
+        lobes: *const PglLobe,
+        n_lobes: u32,
+    );
+    pub fn guiding_set_enabled(enabled: c_int);
+}
+
+#[cfg(feature = "guiding")]
+pub struct GuidingState {
+    pub enabled: bool,
+}
+#[cfg(feature = "guiding")]
+impl GuidingState {
+    pub fn new(enabled: bool) -> Self {
+        unsafe {
+            guiding_set_enabled(if enabled { 1 } else { 0 });
+        }
+        Self { enabled }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "guiding")]
+mod guiding;
+
 use exr::prelude::write_rgb_file;
 use std::ffi::c_int;
 use std::time::Instant;
@@ -433,6 +436,11 @@ fn save_exr_linear(
 
 // ---- main -------------------------------------------------------------------
 fn main() {
+    #[cfg(feature = "guiding")]
+    let _guiding_state = {
+        let enabled = std::env::args().any(|a| a == "--guiding");
+        guiding::GuidingState::new(enabled)
+    };
     let w = 1920;
     let h = 1440;
     let spp = 512;


### PR DESCRIPTION
## Summary
- stub out OpenPGL bridge and GPU guiding interfaces
- add optional `guiding` cargo feature and CLI flag wiring
- document guiding integration notes

## Testing
- `cargo fmt --all --check`


------
https://chatgpt.com/codex/tasks/task_e_68c604f06158832f918411e05ff93839