### PR TITLE
Add RAII wrappers and guiding sample processing

### DIFF
--- a/src/guiding.rs
+++ b/src/guiding.rs
@@ -3,6 +3,15 @@ use std::ffi::{c_int, c_void};
 
 #[cfg(feature = "guiding")]
 #[repr(C)]
+pub struct TrainSample {
+    pub position: [f32; 3],
+    pub dir_in: [f32; 3],
+    pub contrib: [f32; 3],
+    pub is_delta: u32,
+}
+
+#[cfg(feature = "guiding")]
+#[repr(C)]
 pub struct PglRegion {
     pub bmin: [f32; 3],
     pub bmax: [f32; 3],
@@ -52,18 +61,179 @@ extern "C" {
         n_lobes: u32,
     );
     pub fn guiding_set_enabled(enabled: c_int);
+    pub fn guiding_set_train_buffer_size(n: u32);
+    pub fn guiding_map_train_samples(samples: *mut *const TrainSample, count: *mut u32);
+    pub fn guiding_reset_train_write_idx();
+}
+
+#[cfg(feature = "guiding")]
+pub struct Device(*mut c_void);
+#[cfg(feature = "guiding")]
+impl Device {
+    pub fn new(num_threads: i32) -> Option<Self> {
+        let ptr = unsafe { pgl_dev_create(num_threads as c_int) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Self(ptr))
+        }
+    }
+    pub fn as_ptr(&self) -> *mut c_void {
+        self.0
+    }
+}
+#[cfg(feature = "guiding")]
+impl Drop for Device {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { pgl_dev_destroy(self.0) };
+        }
+    }
+}
+
+#[cfg(feature = "guiding")]
+pub struct Field(*mut c_void);
+#[cfg(feature = "guiding")]
+impl Field {
+    pub fn new(dev: &Device, world_min: [f32; 3], world_max: [f32; 3]) -> Option<Self> {
+        let ptr = unsafe { pgl_field_create(dev.as_ptr(), world_min.as_ptr(), world_max.as_ptr()) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Self(ptr))
+        }
+    }
+    pub fn as_ptr(&self) -> *mut c_void {
+        self.0
+    }
+}
+#[cfg(feature = "guiding")]
+impl Drop for Field {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { pgl_field_destroy(self.0) };
+        }
+    }
+}
+
+#[cfg(feature = "guiding")]
+pub struct Samples(*mut c_void);
+#[cfg(feature = "guiding")]
+impl Samples {
+    pub fn new() -> Option<Self> {
+        let ptr = unsafe { pgl_samples_create() };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Self(ptr))
+        }
+    }
+    pub fn as_ptr(&self) -> *mut c_void {
+        self.0
+    }
+}
+#[cfg(feature = "guiding")]
+impl Drop for Samples {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { pgl_samples_destroy(self.0) };
+        }
+    }
 }
 
 #[cfg(feature = "guiding")]
 pub struct GuidingState {
     pub enabled: bool,
+    dev: Option<Device>,
+    field: Option<Field>,
+    samples: Option<Samples>,
+    update_interval: u32,
+    frame_idx: u32,
 }
+
 #[cfg(feature = "guiding")]
 impl GuidingState {
-    pub fn new(enabled: bool) -> Self {
+    pub fn new(
+        enabled: bool,
+        scene_min: [f32; 3],
+        scene_max: [f32; 3],
+        update_interval: u32,
+        train_capacity: u32,
+    ) -> Self {
         unsafe {
             guiding_set_enabled(if enabled { 1 } else { 0 });
+            guiding_set_train_buffer_size(train_capacity);
         }
-        Self { enabled }
+        let dev = if enabled { Device::new(0) } else { None };
+        let field = if enabled {
+            dev.as_ref()
+                .and_then(|d| Field::new(d, scene_min, scene_max))
+        } else {
+            None
+        };
+        let samples = if enabled { Samples::new() } else { None };
+        Self {
+            enabled,
+            dev,
+            field,
+            samples,
+            update_interval,
+            frame_idx: 0,
+        }
+    }
+
+    fn collect_train_samples(&mut self) {
+        if !(self.enabled) {
+            return;
+        }
+        let samples_ptr = match self.samples {
+            Some(ref s) => s.as_ptr(),
+            None => return,
+        };
+        unsafe {
+            let mut ptr: *const TrainSample = std::ptr::null();
+            let mut count: u32 = 0;
+            guiding_map_train_samples(&mut ptr, &mut count);
+            if !ptr.is_null() && count > 0 {
+                let slice = std::slice::from_raw_parts(ptr, count as usize);
+                for ts in slice {
+                    pgl_samples_add_surface(
+                        samples_ptr,
+                        ts.position.as_ptr(),
+                        ts.dir_in.as_ptr(),
+                        ts.contrib.as_ptr(),
+                        ts.is_delta as c_int,
+                    );
+                }
+            }
+            guiding_reset_train_write_idx();
+        }
+    }
+
+    pub fn process_batch(&mut self) {
+        if !self.enabled {
+            return;
+        }
+        self.collect_train_samples();
+        self.frame_idx += 1;
+        if self.frame_idx % self.update_interval == 0 {
+            if let (Some(ref f), Some(ref s)) = (&self.field, &self.samples) {
+                unsafe {
+                    pgl_field_update(f.as_ptr(), s.as_ptr());
+                    let mut regions: *const PglRegion = std::ptr::null();
+                    let mut region_count: u32 = 0;
+                    let mut lobes: *const PglLobe = std::ptr::null();
+                    let mut lobe_count: u32 = 0;
+                    pgl_field_snapshot(
+                        f.as_ptr(),
+                        &mut regions,
+                        &mut region_count,
+                        &mut lobes,
+                        &mut lobe_count,
+                    );
+                    guiding_upload_snapshot(regions, region_count, lobes, lobe_count);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Wrap OpenPGL device, field and sample handles in safe RAII structs
- Initialize guiding with scene bounds and training buffer allocation
- Collect GPU training samples each batch and update guiding field periodically

## Testing
- `cargo fmt --all --check`

Please verify the project builds on your machine and let me know if there are any issues.

------
https://chatgpt.com/codex/tasks/task_e_68c64ae3bf44832fb211a20e45c55185