### PR TITLE
Expose guiding grid and update interval controls

### DIFF
--- a/optix/guiding_gpu.h
+++ b/optix/guiding_gpu.h
@@ -27,6 +27,7 @@ extern "C" {
 void guiding_upload_snapshot(const struct pgl_region* regions,uint32_t n_regions,
                              const struct pgl_lobe* lobes,uint32_t n_lobes);
 void guiding_set_enabled(int enabled);
+void guiding_set_grid_res(int x,int y,int z);
 
 #ifdef __cplusplus
 }

--- a/optix/optix_wrapper.cpp
+++ b/optix/optix_wrapper.cpp
@@ -1266,3 +1266,8 @@ extern "C" __declspec(dllexport)
 void guiding_set_train_buffer_size(uint32_t n){
   g_train_sample_capacity = n;
 }
+
+extern "C" __declspec(dllexport)
+void guiding_set_grid_res(int x,int y,int z){
+  g_guiding_gpu.grid_res = make_int3(x,y,z);
+}

--- a/src/guiding.rs
+++ b/src/guiding.rs
@@ -62,6 +62,7 @@ extern "C" {
     );
     pub fn guiding_set_enabled(enabled: c_int);
     pub fn guiding_set_train_buffer_size(n: u32);
+    pub fn guiding_set_grid_res(x: c_int, y: c_int, z: c_int);
     pub fn guiding_map_train_samples(samples: *mut *const TrainSample, count: *mut u32);
     pub fn guiding_reset_train_write_idx();
 }
@@ -147,6 +148,7 @@ pub struct GuidingState {
     dev: Option<Device>,
     field: Option<Field>,
     samples: Option<Samples>,
+    grid_res: [i32; 3],
     update_interval: u32,
     frame_idx: u32,
 }
@@ -157,12 +159,18 @@ impl GuidingState {
         enabled: bool,
         scene_min: [f32; 3],
         scene_max: [f32; 3],
+        grid_res: [i32; 3],
         update_interval: u32,
         train_capacity: u32,
     ) -> Self {
         unsafe {
             guiding_set_enabled(if enabled { 1 } else { 0 });
             guiding_set_train_buffer_size(train_capacity);
+            guiding_set_grid_res(
+                grid_res[0] as c_int,
+                grid_res[1] as c_int,
+                grid_res[2] as c_int,
+            );
         }
         let dev = if enabled { Device::new(0) } else { None };
         let field = if enabled {
@@ -177,6 +185,7 @@ impl GuidingState {
             dev,
             field,
             samples,
+            grid_res,
             update_interval,
             frame_idx: 0,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -440,6 +440,7 @@ fn main() {
     let mut guiding_state = {
         let mut enabled = false;
         let mut update_interval: u32 = 1;
+        let mut grid_res: [i32; 3] = [1, 1, 1];
         for arg in std::env::args() {
             if arg == "--guiding" {
                 enabled = true;
@@ -447,11 +448,32 @@ fn main() {
             if let Some(v) = arg.strip_prefix("--guide-update-interval=") {
                 update_interval = v.parse().unwrap_or(1);
             }
+            if let Some(v) = arg.strip_prefix("--guide-grid=") {
+                let parts: Vec<_> = v.split(|c| c == 'x' || c == 'X' || c == ',').collect();
+                if parts.len() == 1 {
+                    if let Ok(n) = parts[0].parse() {
+                        grid_res = [n, n, n];
+                    }
+                } else if parts.len() == 3 {
+                    if let (Ok(x), Ok(y), Ok(z)) =
+                        (parts[0].parse(), parts[1].parse(), parts[2].parse())
+                    {
+                        grid_res = [x, y, z];
+                    }
+                }
+            }
         }
         let scene_min = [-1.0, -1.0, 0.0];
         let scene_max = [1.0, 1.0, 2.0];
         let train_cap = 1 << 18;
-        guiding::GuidingState::new(enabled, scene_min, scene_max, update_interval, train_cap)
+        guiding::GuidingState::new(
+            enabled,
+            scene_min,
+            scene_max,
+            grid_res,
+            update_interval,
+            train_cap,
+        )
     };
     let w = 1920;
     let h = 1440;


### PR DESCRIPTION
## Summary
- parse `--guide-grid` and `--guide-update-interval` CLI options
- store guiding grid resolution and update interval in `GuidingState`
- propagate grid resolution to OptiX via new FFI hook

## Testing
- `cargo fmt --all --check`

Please verify the project builds and runs on your machine; the OptiX/CUDA build steps are unavailable in this environment.

------
https://chatgpt.com/codex/tasks/task_e_68c64bfe6868832fa29976d7542a327d