### PR TITLE
Expose training buffer globals for OptiX module

### DIFF
--- a/optix/optix_device.cu
+++ b/optix/optix_device.cu
@@ -7,6 +7,10 @@
 #include <math_constants.h>
 #include "guiding_gpu.cuh"
 
+__device__ TrainSample* g_train_samples = nullptr;
+__device__ uint32_t*    g_train_write_idx = nullptr;
+__device__ uint32_t     g_train_sample_capacity = 0;
+
 // Precomputed constants to avoid repeated division at runtime
 #define INV_UINT16       (1.0f / 65536.0f)
 #define INV_PLASTIC      (1.0f / 1.32471795724474602596f)


### PR DESCRIPTION
## Summary
- define `g_train_samples`, `g_train_write_idx`, and `g_train_sample_capacity` in OptiX device code

## Testing
- `cargo fmt --all --check`
- `nvcc -ptx optix/optix_device.cu -o optix/optix_device.ptx` *(fails: optix.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c65d21ba60832f9afe4a2d730cca19